### PR TITLE
Consider using `$PSNativeCommandUseErrorActionPreference`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - macos-14
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,10 +16,8 @@ tasks:
     deps:
       - setup
     cmds:
-      # pwsh exit with 0 even if ReadLine made errors, the 1+ code is special for an example as parser error
-      # So returns 1+ with the result by yourself in each cmd
       - pwsh -NoProfile --File ./tools/test-all.ps1
-      - pwsh -NoProfile --Command 'Test-ModuleManifest -Path ./PSFzfHistory/*.psd1'
+      - pwsh -NoProfile --Command '$PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = "Stop"; Test-ModuleManifest -Path ./PSFzfHistory/*.psd1'
   fmt:
     deps:
       - setup

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,12 +13,16 @@ tasks:
       - task: test
       - task: lint
   test:
+    deps:
+      - setup
     cmds:
       # pwsh exit with 0 even if ReadLine made errors, the 1+ code is special for an example as parser error
       # So returns 1+ with the result by yourself in each cmd
-      - pwsh --File ./tools/test-all.ps1
-      - pwsh --Command 'Test-ModuleManifest -Path ./PSFzfHistory/*.psd1'
+      - pwsh -NoProfile --File ./tools/test-all.ps1
+      - pwsh -NoProfile --Command 'Test-ModuleManifest -Path ./PSFzfHistory/*.psd1'
   fmt:
+    deps:
+      - setup
     cmds:
       - dprint fmt
       - git ls-files '*.nix' | xargs nix fmt
@@ -30,16 +34,18 @@ tasks:
       - git ls-files '*.nix' | xargs nixfmt --check
   repl:
     cmds:
-      - pwsh -NoExit -File ./tools/repl.ps1
+      - pwsh -NoProfile -NoExit -File ./tools/repl.ps1
   setup:
     cmds:
-      - pwsh -File ./tools/setup.ps1
+      - pwsh -NoProfile -File ./tools/setup.ps1
   bench:
+    deps:
+      - setup
     cmds:
-      - pwsh -File ./tools/benchmark.ps1
+      - pwsh -NoProfile -File ./tools/benchmark.ps1
   deps:
     cmds:
-      - pwsh -File ./tools/deps.ps1
+      - pwsh -NoProfile -File ./tools/deps.ps1
   help:
     cmds:
       - task --list-all

--- a/tools/benchmark.ps1
+++ b/tools/benchmark.ps1
@@ -1,4 +1,7 @@
-﻿# [Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems() cannot be used non tty? as called in CLI
+﻿$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+# [Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems() cannot be used non tty? as called in CLI
 # $lines = [Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems()
 $lines = Get-Content -Path ./fixtures/random-guids.txt
 

--- a/tools/deps.ps1
+++ b/tools/deps.ps1
@@ -1,4 +1,7 @@
-﻿# nix --version - Excluded for Windows, nix targets onle Unix-like OS
+﻿$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+# nix --version - Excluded for Windows, nix targets onle Unix-like OS
 nil --version
 task --version
 dprint --version

--- a/tools/lint-fix.ps1
+++ b/tools/lint-fix.ps1
@@ -1,4 +1,7 @@
-﻿# Do NOT use 'Invoke-ScriptAnalyzer -Recurse -Path .' It includes dotfiles as .direnv
+﻿$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+# Do NOT use 'Invoke-ScriptAnalyzer -Recurse -Path .' It includes dotfiles as .direnv
 # https://github.com/PowerShell/PSScriptAnalyzer/issues/561
 Get-ChildItem -Recurse -Path PSFzfHistory -Include "*.ps*1" |
     ForEach-Object {

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -1,17 +1,17 @@
 ﻿$PSNativeCommandUseErrorActionPreference = $true
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-InstalledModule PSScriptAnalyzer)) {
+if (-not (Get-InstalledModule -ErrorAction SilentlyContinue PSScriptAnalyzer )) {
     # https://github.com/PowerShell/PSScriptAnalyzer
     Install-Module -Name PSScriptAnalyzer -Force
 }
 
-if (-not (Get-InstalledModule Pester)) {
+if (-not (Get-InstalledModule -ErrorAction SilentlyContinue Pester)) {
     # https://github.com/pester/pester
     Install-Module -Name Pester -Force
 }
 
-if (-not (Get-InstalledModule Benchpress)) {
+if (-not (Get-InstalledModule -ErrorAction SilentlyContinue Benchpress)) {
     # https://github.com/StartAutomating/Benchpress
     Install-Module Benchpress -Scope CurrentUser -Force
 }

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -1,6 +1,17 @@
-﻿# https://github.com/PowerShell/PSScriptAnalyzer
-Install-Module -Name PSScriptAnalyzer -Force
-# https://github.com/pester/pester
-Install-Module -Name Pester -Force
-# https://github.com/StartAutomating/Benchpress
-Install-Module Benchpress -Scope CurrentUser -Force
+﻿$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-InstalledModule PSScriptAnalyzer)) {
+    # https://github.com/PowerShell/PSScriptAnalyzer
+    Install-Module -Name PSScriptAnalyzer -Force
+}
+
+if (-not (Get-InstalledModule Pester)) {
+    # https://github.com/pester/pester
+    Install-Module -Name Pester -Force
+}
+
+if (-not (Get-InstalledModule Benchpress)) {
+    # https://github.com/StartAutomating/Benchpress
+    Install-Module Benchpress -Scope CurrentUser -Force
+}

--- a/tools/test-all.ps1
+++ b/tools/test-all.ps1
@@ -1,3 +1,7 @@
+# See https://github.com/kachick/dotfiles/issues/617 for background of this option
+$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
 # https://pester.dev/docs/commands/New-PesterConfiguration
 $config = New-PesterConfiguration
 $config.Run.Exit = $true


### PR DESCRIPTION
- **Specify -NoProfile for all pwsh execution to avoid loading profile errors in local testing**
- **Ensure errexit in most powershell scripts**
- **Skip install module if already installed to avoid blocked process in `task default`**

ref: https://github.com/kachick/dotfiles/issues/617